### PR TITLE
Enable securityContext for container specs

### DIFF
--- a/deployment/manifest_bbo_agent.yml
+++ b/deployment/manifest_bbo_agent.yml
@@ -23,5 +23,7 @@ spec:
         imagePullPolicy: Always
         resources: {}
         ports:
-          - containerPort: 8888 
+          - containerPort: 8888
+        securityContext:
+          allowPrivilegeEscalation: false
 status: {}

--- a/deployment/manifest_dqn_agent.yml
+++ b/deployment/manifest_dqn_agent.yml
@@ -23,5 +23,7 @@ spec:
         imagePullPolicy: Always
         resources: {}
         ports:
-          - containerPort: 8888 
+          - containerPort: 8888
+        securityContext:
+          allowPrivilegeEscalation: false
 status: {}

--- a/deployment/manifest_respons_agent.yml
+++ b/deployment/manifest_respons_agent.yml
@@ -23,5 +23,7 @@ spec:
         imagePullPolicy: Always
         resources: {}
         ports:
-          - containerPort: 8888 
+          - containerPort: 8888
+        securityContext:
+          allowPrivilegeEscalation: false
 status: {}

--- a/deployment/manifest_sac_agent.yml
+++ b/deployment/manifest_sac_agent.yml
@@ -25,5 +25,7 @@ spec:
         imagePullPolicy: Always
         resources: {}
         ports:
-          - containerPort: 8888 
+          - containerPort: 8888
+        securityContext:
+          allowPrivilegeEscalation: false
 status: {}

--- a/deployment/manifest_v0_agent.yml
+++ b/deployment/manifest_v0_agent.yml
@@ -23,5 +23,7 @@ spec:
         imagePullPolicy: Always
         resources: {}
         ports:
-          - containerPort: 8888 
+          - containerPort: 8888
+        securityContext:
+          allowPrivilegeEscalation: false
 status: {}


### PR DESCRIPTION
Enabled the securityContext flag for agent deployments. 